### PR TITLE
some bugfixes to HcamListSpool

### DIFF
--- a/hipercam/spooler.py
+++ b/hipercam/spooler.py
@@ -228,14 +228,14 @@ class HcamListSpool(SpoolerBase):
 
         if self.cnam is None:
             mccd = ccd.MCCD.read(utils.add_extension(fname.strip(), core.HCAM))
-            mccd.head['FILENAME'] = fname
+            mccd.head['FILENAME'] = fname.strip()
             return mccd
         else:
-            ccd = ccd.CCD.read(
+            ccd1 = ccd.CCD.read(
                 utils.add_extension(fname.strip(), core.HCAM), self.cnam
             )
-            ccd.head['FILENAME'] = fname
-            return ccd
+            ccd1.head['FILENAME'] = fname.strip()
+            return ccd1
 
 class HcamServSpool(SpoolerBase):
 


### PR DESCRIPTION
Fixes two bugs, which were visible in Python 3.6:

1. The redefinition of ```ccd``` was causing problems with ```import ccd```. 
2. The ```fname``` could have newline characters which the FITS standard doesn't allow. 