### PR TITLE
Fixes for changes to NGC software that introduce sampling

### DIFF
--- a/hipercam/hcam.py
+++ b/hipercam/hcam.py
@@ -153,8 +153,8 @@ class Rhead:
 
             # get number of samples per pixel, defaulting to 1 for old format
             nsamps = self.header.get('ESO DET NSAMP', 1)
-            self._framesize = (self.header['ESO DET ACQ1 WIN NX'] *
-                               self.header['ESO DET ACQ1 WIN NY'] // nsamps)
+            self._framesize = 36 + (self.header['ESO DET ACQ1 WIN NX'] *
+                                    self.header['ESO DET ACQ1 WIN NY'] // nsamps)
         else:
             # open the file
             self._ffile = open(add_extension(fname, HRAW),'rb')

--- a/hipercam/hcam.py
+++ b/hipercam/hcam.py
@@ -153,7 +153,8 @@ class Rhead:
 
             # get number of samples per pixel, defaulting to 1 for old format
             nsamps = self.header.get('ESO DET NSAMP', 1)
-            self._framesize = self.hdr['ESO DET ACQ1 WIN NX'] * self.hdr['ESO DET ACQ1 WIN NY'] // nsamps
+            self._framesize = (self.header['ESO DET ACQ1 WIN NX'] *
+                               self.header['ESO DET ACQ1 WIN NY'] // nsamps)
         else:
             # open the file
             self._ffile = open(add_extension(fname, HRAW),'rb')


### PR DESCRIPTION
*do not merge yet* - needs testing.

These are some of the changes that are needed to accommodate for the introduction of changes in the NGC software. As background these changes were made to make fast readout mode work. This meant the data order from the NGC controller changed, with the data coming in bunches of 4, e.g

```
CCD1[a,b,c,d][0]
CCD1[a,b,c,d][1]
CCD1[a,b,c,d][2]
CCD1[a,b,c,d][3]
CCD2[a,b,c,d][0]
CCD2[a,b,c,d][1]
CCD2[a,b,c,d][2]
CCD2[a,b,c,d][3]
.....etc...
CCD5[a,b,c,d][2]
CCD5[a,b,c,d][3]
```

Slow readout has been implemented as fast readout with 4 samples per pixel. Adding multiple samples to the data changes the pixel order yet again, but Gao averages the samples in his acquisition task. The net result of these changes is that the data order in slow readout is unchanged from before. 

The number of samples per pixel is written to the headers in ```ESO DET NSAMP```.

There's also two minor tweaks that have been made to fix the calculation of ```_framesize``` for runs that are in progress, and one to accommodate what happens when GPS hardware is not attached.