### PR TITLE
Improve shifting of apertures. 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,47 +13,55 @@ following third-party packages. At the moment I suggest you get these
 installed first (you will very likely have several of them already); in the
 future I might try to make it more automatic:
 
-  astropy    : widely used astronomical Python package with lots of useful
-               stuff.
+  astropy :
+         astronomical Python package with lots of useful
+         stuff.
 
-  cython     : C-extensions for Python. Widely used package used to interface
-               to C-libraries and to enable faster code when critical.
+  cython :
+         C-extensions for Python. Widely used package used to interface
+         to C-libraries and to enable faster code when critical.
 
-  matplotlib : standard plotting package for Python.
+  matplotlib :
+         standard plotting package for Python.
 
-  numpy      : Python's numerical data package. Highly likely you will have
-               it, but note that you need at least version 1.12 to provide
-               `numpy.flip`.
+  numpy :
+         Python's numerical data package. Highly likely you will have
+         it, but note that you need at least version 1.12 to provide
+         `numpy.flip`.
 
-  trm.pgplot : my own Cythonised wrapper for PGPLOT which I wrote specifically
-               for hipercam although it is entirely independent of it. PGPLOT
-               is needed for some of the faster plots as matplotlib is way too
-               slow. PGPLOT itself must be installed for this to work. Once
-               you have PGPLOT, you can get trm.pgplot from my github site
-               with::
+  trm.pgplot :
+         my own Cythonised wrapper for PGPLOT which I wrote specifically
+         for hipercam although it is entirely independent of it. PGPLOT
+         is needed for some of the faster plots as matplotlib is way too
+         slow. PGPLOT itself must be installed for this to work. Once
+         you have PGPLOT, you can get trm.pgplot from my github site
+         with::
 
-                 git clone https://github.com/trmrsh/trm-pgplot
+             git clone https://github.com/trmrsh/trm-pgplot
 
-               trm.pgplot is not to be confused with "ppgplot" which although
-               very similar, is a more hand-crafted version with some
-               differences in the calls.
+         trm.pgplot is not to be confused with "ppgplot" which although
+         very similar, is a more hand-crafted version with some
+         differences in the calls.
 
-  websocket  : for talking to the hipercam server. You want the Websocket
-               client library which you can get from::
+  websocket :
+         for talking to the hipercam server. You want the Websocket
+         client library which you can get from::
 
-                 https://github.com/websocket-client/websocket-client
+             https://github.com/websocket-client/websocket-client
 
-  sep        : astronomical source extractor for the aligntool script
+  sep :
+         astronomical source extractor for the aligntool script
 
-  setuptools_scm : package to manage version numbers from the git repository
+  setuptools_scm :
+         package to manage version numbers from the git repository
 
 
-Once you have all these, then get the hipercam pipeline software itself using:
+Once you have all these, then get the hipercam pipeline software itself using::
 
   git clone https://github.com/HiPERCAM/hipercam.git
 
-This will create a directory (**). Change to that and then it's the usual
-Python installation procedure:
+This will create a directory (** reference from below). Change to that 
+and then it's the usual Python installation procedure:
 
   python setup.py install
 
@@ -78,6 +86,6 @@ If you have multiple versions of python, then you need to specify python3, and
 the last line should use pip3.
 
 If you have already installed but want to update, then go to the directory
-created at step ** above and type `git pull` and then re-install.
+created at step ** above and type ``git pull`` and then re-install.
 
 Tom Marsh

--- a/docs/reduction.rst
+++ b/docs/reduction.rst
@@ -183,6 +183,30 @@ field file. You should experiment with changing settings such as the
 extraction lines and aperture re-position section to get a feel for the
 different parameters.
 
+The two keys elements to get right in the reduction files are the sections
+concerning how the apertures are re-located and the extraction. The former is
+the trickier one. The apertures are re-located in a two-step process. First a
+search is made in a square box centred on the last position measured for a
+given target. The size of this box (``search_half_width``) is important. If it
+too small, your target may jump beyond it and the reduction is likely to fail
+as that will set an error condition and the target may never be recovered. On
+the other hand too large, and you could easily end up jumping to a nearby
+object. (The search identifies the brightest target in the box after gaussian
+smoothing to reduce the effects of cosmic rays.) This is where rerence targets
+come in. A well chosen reference target (bright, in an isolated region), can
+allow you to set a relatively large search box, robust against large
+jumps. The shifts from the reference targets are used to place the profile fit
+boxes and avoid the need to searches over non-reference targets. This can be a
+great help on faint targets. The main decision on extraction are variable or
+fixed apertures (usually recommend variable), optimal or normal extraction
+(usually recommend normal), and the various aperture radii. It is recommended
+to plot the images in reduce at least once zoomed in on your target to get a
+feel for this. Depending on circumstances, significant improvments to the
+photometry can be made with careful choices on these parameters; do not assume
+that the file produced by |genred| is in any way the last word; there is no
+automatic way to come up with the ideal choices which depend upon the nature
+of the field and conditions.
+
 Plotting results
 ================
 

--- a/hipercam/core.py
+++ b/hipercam/core.py
@@ -22,7 +22,7 @@ __all__ = (
 # Format: YYYYMMDD.# where # is an integer to allow for multiple
 # versions in a day, although that should be rare and it should
 # almost always be '1'
-REDUCE_FILE_VERSION = '20180519.1'
+REDUCE_FILE_VERSION = '20180608'
 
 # Standard file extensions
 FIELD = '.fld'

--- a/hipercam/scripts/genred.py
+++ b/hipercam/scripts/genred.py
@@ -115,21 +115,23 @@ def genred(args=None):
         fwhmmin  : float [hidden]
            the default FWHM to use when fitting, unbinned pixels.
 
-        halfwidth : int [hidden]
-           half width in (binned) pixels for the target searches and
-           profile fits
+        searchwidth : int [hidden]
+           half width in (binned) pixels for the target searches
 
-        thresh     : float [hidden]
+        fitwidth : int [hidden]
+           half width in (binned) pixels for the profile fits
+
+        thresh : float [hidden]
            RMS rejection threshold for profile fits.
 
-        heightmin  : float [hidden]
+        heightmin : float [hidden]
            minimum peak height for a fit to be accepted
 
-        rfac     : float [hidden]
+        rfac : float [hidden]
            target aperture radius relative to the FWHM for 'variable' aperture
            photometry. Usual values 1.5 to 2.5.
 
-        rmin     : float [hidden]
+        rmin : float [hidden]
            minimum target aperture radius [unbinned pixels]
 
         rmax     : float [hidden]
@@ -246,14 +248,14 @@ warn = 5 50000 64000
             maxcpu = 5
         elif inst == 'ultracam':
             warn_levels = """# Warning levels for instrument = ULTRACAM
-warn = 1 28000 65500
-warn = 2 28000 65500
-warn = 3 50000 65500
+warn = 1 28000 64000
+warn = 2 28000 64000
+warn = 3 50000 64000
 """
             maxcpu = 3
         elif inst == 'ultraspec':
             warn_levels = """# Warning levels for instrument = ULTRASPEC
-warn = 1 65000 65500
+warn = 1 60000 64000
 """
             maxcpu = 1
 
@@ -325,8 +327,12 @@ warn = 1 65000 65500
             'fwhmmin','minimum FWHM, unbinned pixels',1.5,0.
         )
 
-        half_width = cl.get_value(
-            'halfwidth', 'half widths for search & fits, pixels', 21, 7
+        search_half_width = cl.get_value(
+            'searchwidth', 'half width for initial searches, unbinned pixels', 11, 3
+        )
+
+        fit_half_width = cl.get_value(
+            'fitwidth', 'half width for profile fits, unbinned pixels', 21, 5
         )
 
         thresh = cl.get_value(
@@ -556,8 +562,8 @@ warn = 1 65000 65500
                 hipercam_version=hipercam_version, location=location,
                 comm_seeing=comm_seeing, extendx=extendx,
                 comm_position=comm_position, scale=scale,
-                warn_levels=warn_levels, ncpu=ncpu, half_width=half_width,
-                profile_type=profile_type, height_min=height_min,
+                warn_levels=warn_levels, ncpu=ncpu, search_half_width=search_half_width,
+                fit_half_width=fit_half_width, profile_type=profile_type, height_min=height_min,
                 beta=beta, beta_max=beta_max, thresh=thresh
             )
         )
@@ -644,8 +650,7 @@ ncpu = {ncpu}
 aperfile   = {apfile}   # file of software apertures for each CCD
 location   = {location} # aperture locations: 'fixed' or 'variable'
 
-search_half_width_ref  = {half_width:d}   # for initial search around reference aperture, unbinned pixels
-search_half_width_non  = {half_width:d}    # for initial search around non-reference aperture, unbinned pixels
+search_half_width = {search_half_width:d} # for initial search for objects around previous position, unbinned pixels
 search_smooth_fwhm     = {smooth_fwhm:.1f}    # smoothing FWHM, binned pixels
 
 fit_method     = {profile_type}   # gaussian or moffat
@@ -653,9 +658,9 @@ fit_beta       = {beta:.1f}       # Moffat exponent
 fit_beta_max   = {beta_max:.1f}   # max Moffat expt for later fits
 fit_fwhm       = {fwhm:.1f}   # FWHM, unbinned pixels
 fit_fwhm_min   = {fwhm_min:.1f}   # Minimum FWHM, unbinned pixels
-fit_ndiv       = 0         # sub-pixellation factor
-fit_fwhm_fixed = no        # Slightly faster not to fit the FWHM.
-fit_half_width = {half_width:d}   # for fit, unbinned pixels
+fit_ndiv       = 0   # sub-pixellation factor
+fit_fwhm_fixed = no  # Might want to set = 'yes' for defocussed images
+fit_half_width = {fit_half_width:d}   # for fit, unbinned pixels
 fit_thresh     = {thresh:.2f}     # RMS rejection threshold for fits
 fit_height_min = {height_min:.1f} # minimum height to accept a fit
 

--- a/hipercam/scripts/genred.py
+++ b/hipercam/scripts/genred.py
@@ -310,7 +310,7 @@ warn = 1 60000 64000
         comm_position = '#' if location == 'fixed' else ''
 
         smooth_fwhm = cl.get_value(
-            'smoothfwhm','search smoothing FWHM [unbinned pixels]',6.,3.
+            'smoothfwhm','search smoothing FWHM [binned pixels]',6.,3.
         )
 
         profile_type = cl.get_value(

--- a/hipercam/scripts/genred.py
+++ b/hipercam/scripts/genred.py
@@ -143,6 +143,12 @@ def genred(args=None):
         souter   : float [hidden]
            outer sky aperture radius [unbinned pixels]
 
+        readout : float | string [hidden]
+           readout noise, RMS ADU. Can either be a single value or an hcm file.
+
+        gain : float [hidden]
+           gain, electrons per ADU. Can either be a single value or an hcm file.
+
         scale    : float [hidden]
            image scale in arcsec/pixel
 
@@ -181,6 +187,8 @@ def genred(args=None):
         cl.register('rmax', Cline.LOCAL, Cline.HIDE)
         cl.register('sinner', Cline.LOCAL, Cline.HIDE)
         cl.register('souter', Cline.LOCAL, Cline.HIDE)
+        cl.register('readout', Cline.LOCAL, Cline.HIDE)
+        cl.register('gain', Cline.LOCAL, Cline.HIDE)
         cl.register('scale', Cline.LOCAL, Cline.HIDE)
 
         # get inputs
@@ -362,6 +370,15 @@ warn = 1 60000 64000
 
         souter = cl.get_value(
             'souter','outer sky aperture radius [unbinned pixels]',50.,sinner+1
+        )
+
+
+        readout = cl.get_value(
+            'readout', 'readout noise, RMS ADU (float or file name)', '4.5'
+        )
+
+        gain = cl.get_value(
+            'gain', 'gain, electrons/ADU, (float or file name)', '1.1'
         )
 
         scale = cl.get_value(
@@ -564,7 +581,7 @@ warn = 1 60000 64000
                 comm_position=comm_position, scale=scale,
                 warn_levels=warn_levels, ncpu=ncpu, search_half_width=search_half_width,
                 fit_half_width=fit_half_width, profile_type=profile_type, height_min=height_min,
-                beta=beta, beta_max=beta_max, thresh=thresh
+                beta=beta, beta_max=beta_max, thresh=thresh, readout=readout, gain=gain
             )
         )
 
@@ -580,14 +597,14 @@ warn = 1 60000 64000
 #################################################################
 
 TEMPLATE = """#
-# This is a HiPERCAM "reduce file" which defines the operation of the
-# reduce script. It was written by the HiPERCAM pipeline command 'genred'.
-# It consists of a series of sections each of which contains a number of
-# parameters. The file is self-documenting on the meaning of these
+# This is a HiPERCAM "reduce file" which defines the operation
+# of the reduce script. It was written by the HiPERCAM pipeline command
+# 'genred'.  It consists of a series of sections each of which contains a
+# number of parameters. The file is self-documenting on the meaning of these
 # parameters. The idea is that these are to large extent unchanging and it
-# would be annoying to be prompted every time for them, but it also acts as
-# a record of how reduction was carried out and is fed into the log file
-# produce by 'reduce'.
+# would be annoying to be prompted every time for them, but it also acts as a
+# record of how reduction was carried out and is fed into the log file produce
+# by 'reduce'.
 #
 # File written on {tstamp}
 #
@@ -605,63 +622,75 @@ TEMPLATE = """#
 # 'git'.
 
 [general]
-version   = {version}  # must be compatible with the version in reduce
+version = {version} # must be compatible with the version in reduce
 
-ldevice  = 1/xs  # PGPLOT plot device for light curve plots
-lwidth   = 0     # light curve plot width, inches, 0 to let program choose
-lheight  = 0     # light curve plot height, inches
+ldevice = 1/xs # PGPLOT plot device for light curve plots
+lwidth = 0 # light curve plot width, inches, 0 to let program choose
+lheight = 0 # light curve plot height, inches
 
-idevice  = 2/xs  # PGPLOT plot device for image plots [if implot True]
-iwidth   = 0     # image curve plot width, inches, 0 to let program choose
-iheight  = 0     # image curve plot height, inches
+idevice = 2/xs # PGPLOT plot device for image plots [if implot True]
+iwidth = 0 # image curve plot width, inches, 0 to let program choose
+iheight = 0 # image curve plot height, inches
 
-# series of count levels at which warnings will be triggered for
-# (a) non linearity and (b) saturation. Each line starts 'warn =',
-# and is then followed by the CCD label, the non-linearity level
-# and the saturation level
+# series of count levels at which warnings will be triggered for (a) non
+# linearity and (b) saturation. Each line starts 'warn =', and is then
+# followed by the CCD label, the non-linearity level and the saturation level
 
 {warn_levels}
 
 # The aperture reposition and extraction stages can be run in separate CPUs in
 # parallel for each CCD. The next parameter is the number of CPUs to use. The
 # maximum useful number is the number of CCDs in the instrument, e.g. 5 for
-# HiPERCAM. You probably also want to leave at leat one CPU to do other stuff,
-# but if you have more than 2 CPUs, this parameter may help speed things a
-# little.
+# HiPERCAM. You probably also want to leave at least one CPU to do other stuff,
+# but if you have more than 2 CPUs, this parameter may help speed things.
 ncpu = {ncpu}
 
 # The next section defines how the apertures are re-positioned from frame to
 # frame. Apertures are re-positioned through a combination of a search near a
-# start location followed by a 2D fit. Several parameters below are associated
-# with this process. If there are reference apertures, they are located first
-# to give a mean shift. The search on non-reference apertures can then be
-# tightened. If the aperture are chosen to be fixed, there will be no search
-# or fit carried out in which case you must choose 'fixed' as well when it
-# comes the extraction since otherwise it needs a FWHM. The most obscure
-# parameter below is probably 'fit_ndiv'. If this is made > 0, the fit routine
-# attempts to allow for pixellation by evaluating the profile at multiple
-# point in each pixel of the fit. First it will evaluate the profile for every
-# unbinned pixel with a binned pixel if the pixels are binned; second, it will
-# evaluate the profile over an ndiv by ndiv square grid within each unbinned
-# pixel. Obviously this will slow things, but it could help if your images are
-# under-sampled.
+# start location followed by a 2D profile fit. Several parameters below are
+# associated with this process and setting these right can be the key to a
+# successful reduction. If there are reference apertures, they are located
+# first to give a mean shift. This is used to bypass the initial search on any
+# non-reference apertures. The search is carried out by first extracting a
+# square sub-window centred on the last good position of a target. This is
+# then smoothed by a gaussian, and the peak is taken as the initial position
+# for later profile fits. The gaussian should have a width comparable to the
+# targets FWHM and is to make the process more robust against cosmic rays. The
+# width of the search box depends on how good the telescope guiding is. In
+# particular if at some point there is a sudden jump in position, the box may
+# have to be large enough to cope. Well-chosen reference targets, which above
+# all should be isolated, can help this process a great deal. The boxes for
+# the fits need to be large enough to include the target and a bit of sky to
+# ensure that the FWHM is accurately measured. Remember that seeing can flare
+# of course. If your target was defocussed, a gaussian or Moffat function will
+# be a poor fit and you may be better keeping the FWHM fixed at a large value
+# comparable to the widths of your defeoccused images. If the apertures are
+# chosen to be fixed, there will be no search or fit carried out in which case
+# you must choose 'fixed' as well when it comes the extraction since otherwise
+# it needs a FWHM. The most obscure parameter below is probably 'fit_ndiv'. If
+# this is made > 0, the fit routine attempts to allow for pixellation by
+# evaluating the profile at multiple point in each pixel of the fit. First it
+# will evaluate the profile for every unbinned pixel with a binned pixel if
+# the pixels are binned; second, it will evaluate the profile over an ndiv by
+# ndiv square grid within each unbinned pixel. Obviously this will slow
+# things, but it could help if your images are under-sampled.
 
 [apertures]
-aperfile   = {apfile}   # file of software apertures for each CCD
-location   = {location} # aperture locations: 'fixed' or 'variable'
+aperfile = {apfile} # file of software apertures for each CCD
+location = {location} # aperture locations: 'fixed' or 'variable'
 
 search_half_width = {search_half_width:d} # for initial search for objects around previous position, unbinned pixels
-search_smooth_fwhm     = {smooth_fwhm:.1f}    # smoothing FWHM, binned pixels
+search_smooth_fwhm = {smooth_fwhm:.1f}    # smoothing FWHM, binned pixels
 
-fit_method     = {profile_type}   # gaussian or moffat
-fit_beta       = {beta:.1f}       # Moffat exponent
-fit_beta_max   = {beta_max:.1f}   # max Moffat expt for later fits
-fit_fwhm       = {fwhm:.1f}   # FWHM, unbinned pixels
-fit_fwhm_min   = {fwhm_min:.1f}   # Minimum FWHM, unbinned pixels
-fit_ndiv       = 0   # sub-pixellation factor
-fit_fwhm_fixed = no  # Might want to set = 'yes' for defocussed images
-fit_half_width = {fit_half_width:d}   # for fit, unbinned pixels
-fit_thresh     = {thresh:.2f}     # RMS rejection threshold for fits
+fit_method = {profile_type} # gaussian or moffat
+fit_beta = {beta:.1f} # Moffat exponent
+fit_beta_max = {beta_max:.1f} # max Moffat expt for later fits
+fit_fwhm = {fwhm:.1f} # FWHM, unbinned pixels
+fit_fwhm_min = {fwhm_min:.1f} # Minimum FWHM, unbinned pixels
+fit_ndiv = 0 # sub-pixellation factor
+fit_fwhm_fixed = no # Might want to set = 'yes' for defocussed images
+fit_half_width = {fit_half_width:d} # for fit, unbinned pixels
+fit_thresh = {thresh:.2f} # RMS rejection threshold for fits
 fit_height_min = {height_min:.1f} # minimum height to accept a fit
 
 # The next lines define how the apertures will be re-sized and how the flux
@@ -683,8 +712,8 @@ fit_height_min = {height_min:.1f} # minimum height to accept a fit
 # aperture radius, the inner sky radius and finally the outer sky radius. The
 # mininum and maximum also apply if you choose 'fixed' apertures and can be
 # used to override whatever value comes from the aperture file. A common
-# approach is set them equal to each other to give a fixed value, especially for
-# the sky where one does not necessarily want the radii to vary.
+# approach is set them equal to each other to give a fixed value, especially
+# for the sky where one does not necessarily want the radii to vary.
 
 [extraction]
 {extraction}
@@ -695,19 +724,18 @@ fit_height_min = {height_min:.1f} # minimum height to accept a fit
 # here as a comparator. 
 
 [sky]
-method = clipped    # 'clipped' | 'median'
-error  = variance   # 'variance' | 'photon': first uses actual variance of sky
-thresh = 3.         # threshold in terms of RMS for 'clipped'
+method = clipped # 'clipped' | 'median'
+error  = variance # 'variance' | 'photon': first uses actual variance of sky
+thresh = 3. # threshold in terms of RMS for 'clipped'
 
 # Calibration frames and constants
 [calibration]
-crop = yes    # Crop calibrations to match the data
-bias = {bias}    # Bias frame, blank to ignore
-flat = {flat}    # Flat field frame, blank to ignore
-dark = {dark}    # Dark frame, blank to ignore
-readout = 3.  # RMS ADU. Float or string name of a file
-gain = 1.     # Gain, electrons/ADU. Float or string name of a file
-
+crop = yes # Crop calibrations to match the data
+bias = {bias} # Bias frame, blank to ignore
+flat = {flat} # Flat field frame, blank to ignore
+dark = {dark} # Dark frame, blank to ignore
+readout = {readout} # RMS ADU. Float or string name of a file
+gain = {gain} # Gain, electrons/ADU. Float or string name of a file
 
 # The light curve plot which consists of light curves, X & Y poistions,
 # the transmission and seeing. All but the light curves can be switched
@@ -715,8 +743,8 @@ gain = 1.     # Gain, electrons/ADU. Float or string name of a file
 # parameters.
 
 [lcplot]
-xrange  = 0    # maximum range in X to plot (minutes), <= 0 for everything
-extend_x = {extendx:.2f}  # amount by which to extend xrange, minutes.
+xrange  = 0 # maximum range in X to plot (minutes), <= 0 for everything
+extend_x = {extendx:.2f} # amount by which to extend xrange, minutes.
 
 # The light curve panel (must be present). Mostly obvious, then a series of
 # lines, each starting 'plot' which specify one light curve to be plotted
@@ -727,10 +755,10 @@ extend_x = {extendx:.2f}  # amount by which to extend xrange, minutes.
 # defined to have unit height and all others are scaled relative to this.
 
 [light]
-linear  = {linear}  # linear vertical scale (else magnitudes): 'yes' or 'no'
-y_fixed = no   # keep a fixed vertical range or not: 'yes' or 'no'
-y1 = 0         # initial lower y value
-y2 = 0         # initial upper y value. y1=y2 for auto scaling
+linear  = {linear} # linear vertical scale (else magnitudes): 'yes' or 'no'
+y_fixed = no # keep a fixed vertical range or not: 'yes' or 'no'
+y1 = 0 # initial lower y value
+y2 = 0 # initial upper y value. y1=y2 for auto scaling
 extend_y = 0.1 # fraction of plot height to extend when rescaling
 
 # line or lines defining the targets to plot
@@ -742,14 +770,14 @@ extend_y = 0.1 # fraction of plot height to extend when rescaling
 # have multiple plot lines.
 
 {comm_position}[position]
-{comm_position}height  = 0.5    # height relative to light curve plot
-{comm_position}x_fixed = no     # keep X-position vertical range fixed
-{comm_position}x_min   = -5     # lower limit for X-position
-{comm_position}x_max   = +5     # upper limit for X-position
-{comm_position}y_fixed = no     # keep Y-position vertical range fixed
-{comm_position}y_min   = -5     # lower limit for Y-position
-{comm_position}y_max   = +5     # upper limit for Y-position
-{comm_position}extend_y = 0.2  # Vertical extension fraction if limits exceeded
+{comm_position}height = 0.5 # height relative to light curve plot
+{comm_position}x_fixed = no # keep X-position vertical range fixed
+{comm_position}x_min = -5 # lower limit for X-position
+{comm_position}x_max = +5 # upper limit for X-position
+{comm_position}y_fixed = no # keep Y-position vertical range fixed
+{comm_position}y_min = -5 # lower limit for Y-position
+{comm_position}y_max = +5 # upper limit for Y-position
+{comm_position}extend_y = 0.2 # Vertical extension fraction if limits exceeded
 
 # line or lines defining the targets to plot
 {position_plot}
@@ -762,8 +790,8 @@ extend_y = 0.1 # fraction of plot height to extend when rescaling
 # cloud clears).
 
 [transmission]
-height = 0.5      # height relative to the light curve plot
-ymax   = 110      # Maximum transmission to plot (>= 100 to slow replotting)
+height = 0.5 # height relative to the light curve plot
+ymax = 110 # Maximum transmission to plot (>= 100 to slow replotting)
 
 # line or lines defining the targets to plot
 {transmission_plot}
@@ -774,10 +802,10 @@ ymax   = 110      # Maximum transmission to plot (>= 100 to slow replotting)
 # measured.
 
 {comm_seeing}[seeing]
-{comm_seeing}height = 0.5   # height relative to the light curve plot
-{comm_seeing}ymax = 1.999   # Initial maximum seeing
-{comm_seeing}y_fixed = no   # fix the seeing scale (or not)
-{comm_seeing}scale = {scale:.2f}  # Arcsec per unbinned pixel
+{comm_seeing}height = 0.5 # height relative to the light curve plot
+{comm_seeing}ymax = 1.999 # Initial maximum seeing
+{comm_seeing}y_fixed = no # fix the seeing scale (or not)
+{comm_seeing}scale = {scale:.2f} # Arcsec per unbinned pixel
 {comm_seeing}extend_y = 0.2 # Y extension fraction if out of range and not fixed
 
 # line or lines defining the targets to plot

--- a/hipercam/scripts/reduce.py
+++ b/hipercam/scripts/reduce.py
@@ -1728,6 +1728,7 @@ def moveApers(cnam, ccd, read, gain, ccdaper, ccdwin, rfile, store):
     for apnam, aper in ccdaper.items():
 
         if aper.ref:
+
             if store[apnam]['fwhme'] <= 0.:
                 # Move failed reference fit to the mean shift
                 aper.x += xshift
@@ -1758,9 +1759,11 @@ def moveApers(cnam, ccd, read, gain, ccdaper, ccdwin, rfile, store):
                     x,y,peak = swdata.find(apsec['search_smooth_fwhm'], False)
 
                 else:
-                    # simply apply the reference aperture mean shift
+                    # simply apply the reference aperture mean shift and
+                    # extract flux at nearest pixel
                     x = aper.x+xshift
                     y = aper.y+yshift
+                    peak = swdata.data[int(round(swdata.y_pixel(y))),int(round(swdata.y_pixel(x)))]
 
                 # now for a more refined fit. First extract fit Window
                 fhbox = apsec['fit_half_width']

--- a/hipercam/scripts/reduce.py
+++ b/hipercam/scripts/reduce.py
@@ -49,7 +49,8 @@ def reduce(args=None):
     reduce is primarily configured from a file with extension ".red". This
     contains a series of directives, e.g. to say how to re-position and
     re-size the apertures. An initial reduce file is best generated with
-    the script |genred| after you have created an aperture file.
+    the script |genred| after you have created an aperture file. This contains
+    lots of help on what to do.
 
     A reduce run can be terminated at any point with ctrl-C without doing
     any harm. You may often want to do this at the start in order to adjust

--- a/hipercam/scripts/reduce.py
+++ b/hipercam/scripts/reduce.py
@@ -1621,7 +1621,7 @@ def moveApers(cnam, ccd, read, gain, ccdaper, ccdwin, rfile, store):
                 if swdata.distance(x,y) < 0.5:
                     raise hcam.HipercamError(
                         'Fitted position ({:.1f},{:.1f}) too close to or beyond edge of search window = {!s}'.format(
-                            x,y,fwdata.winhead.format())
+                            x,y,swdata.winhead.format())
                     )
 
                 if height > apsec['fit_height_min']:
@@ -1803,7 +1803,7 @@ def moveApers(cnam, ccd, read, gain, ccdaper, ccdwin, rfile, store):
                 if swdata.distance(x,y) < 0.5:
                     raise hcam.HipercamError(
                         'Fitted position ({:.1f},{:.1f}) too close to or beyond edge of search window = {!s}'.format(
-                            x,y,fwdata.winhead.format())
+                            x,y,swdata.winhead.format())
                     )
 
                 if height > apsec['fit_height_min']:

--- a/hipercam/scripts/reduce.py
+++ b/hipercam/scripts/reduce.py
@@ -662,7 +662,28 @@ def reduce(args=None):
 
                     # This is the very first OK data we have. There are a few
                     # things we do now on the assumption that all the data frames
-                    # will have the same format.
+                    # will have the same format. Begin by checking for some poor
+                    # settings
+                    xbin = ybin = 1
+                    for cnam in mccd:
+                        for wnam in mccd[cnam]:
+                            xbin = max(xbin, mccd[cnam][wnam].xbin)
+                            ybin = max(ybin, mccd[cnam][wnam].ybin)
+
+                    if rfile['apertures']['fit_half_width'] < 3*max(xbin, ybin):
+                        print(
+                            ("'** fit_half_width' < 3*max(xbin,ybin) ({:.1f} vs {:d}); profile fits"
+                             " will fail. Please increase its value in the reduce file.").format(
+                                rfile['apertures']['fit_half_width'], 3*max(xbin, ybin)
+                                ), file=sys.stderr)
+                        break
+
+                    elif rfile['apertures']['fit_half_width'] < 5*max(xbin,ybin):
+                        warnings.warn(
+                            ("'** fit_half_width' < 5*max(xbin,ybin) ({:.1f} vs {:d}) ==> small windows for"
+                             " profile fits. Advise increasing its value in the reduce file if possible.").format(
+                                rfile['apertures']['fit_half_width'], 5*max(xbin,ybin)
+                                ))
 
                     if  rfile['calibration']['crop']:
                         # Trim the calibrations, on the assumption that all
@@ -1787,7 +1808,6 @@ def moveApers(cnam, ccd, read, gain, ccdaper, ccdwin, rfile, store):
                 fit_beta = min(fit_beta, apsec['fit_beta_max'])
 
                 # refine the Aperture position by fitting the profile
-
                 (sky, height, x, y, fwhm, beta), \
                     (esky, eheight, ex, ey, efwhm, ebeta), \
                     extras = \

--- a/hipercam/scripts/reduce.py
+++ b/hipercam/scripts/reduce.py
@@ -1763,7 +1763,7 @@ def moveApers(cnam, ccd, read, gain, ccdaper, ccdwin, rfile, store):
                     # extract flux at nearest pixel
                     x = aper.x+xshift
                     y = aper.y+yshift
-                    peak = swdata.data[int(round(swdata.y_pixel(y))),int(round(swdata.y_pixel(x)))]
+                    peak = swdata.data[int(round(swdata.y_pixel(y))),int(round(swdata.x_pixel(x)))]
 
                 # now for a more refined fit. First extract fit Window
                 fhbox = apsec['fit_half_width']

--- a/hipercam/scripts/reduce.py
+++ b/hipercam/scripts/reduce.py
@@ -1616,6 +1616,12 @@ def moveApers(cnam, ccd, read, gain, ccdaper, ccdwin, rfile, store):
                                  apsec['fit_thresh'], apsec['fit_ndiv']
                              )
 
+                # check that x, y are in range
+                if fwdata.distance(x,y) < 0.5:
+                    raise hcam.HipercamError(
+                        'Fitted position ({:.1f},{:.1f}) too close or outside window = {!s}'.format(x,y,fwdata.winhead())
+                    )
+
                 if height > apsec['fit_height_min']:
                     dx = x - aper.x
                     wx = 1./ex**2
@@ -1781,6 +1787,12 @@ def moveApers(cnam, ccd, read, gain, ccdaper, ccdwin, rfile, store):
                                  fwread.data, fwgain.data,
                                  apsec['fit_thresh'], apsec['fit_ndiv']
                              )
+
+                # check that x, y are in range
+                if fwdata.distance(x,y) < 0.5:
+                    raise hcam.HipercamError(
+                        'Fitted position ({:.1f},{:.1f}) too close or outside window = {!s}'.format(x,y,fwdata.winhead())
+                    )
 
                 if height > apsec['fit_height_min']:
                     # store some stuff for next time and for passing onto

--- a/hipercam/scripts/reduce.py
+++ b/hipercam/scripts/reduce.py
@@ -1193,8 +1193,7 @@ class Rfile(OrderedDict):
         # type conversions
         toBool(rfile,'apertures','fit_fwhm_fixed')
 
-        apsec['search_half_width_ref'] = int(apsec['search_half_width_ref'])
-        apsec['search_half_width_non'] = int(apsec['search_half_width_non'])
+        apsec['search_half_width'] = int(apsec['search_half_width'])
         apsec['search_smooth_fwhm'] = float(apsec['search_smooth_fwhm'])
         apsec['fit_fwhm'] = float(apsec['fit_fwhm'])
         apsec['fit_fwhm_min'] = float(apsec['fit_fwhm_min'])
@@ -1555,15 +1554,17 @@ def moveApers(cnam, ccd, read, gain, ccdaper, ccdwin, rfile, store):
             }
         return
 
-    # first of all try to get a mean shift from the reference apertures.  we
-    # move any of these apertures that are fitted OK
+    # some initialisations
     xsum, ysum = 0., 0.
     wxsum, wysum = 0., 0.
     ref = False
-
-    # the next part is used to work out weighted mean FWHM and beta values
     fsum, wfsum = 0, 0
     bsum, wbsum = 0, 0
+    shbox = apsec['search_half_width']
+
+    # first of all try to get a mean shift from the reference apertures.  we
+    # move any of these apertures that are fitted OK the next part is used to
+    # work out weighted mean FWHM and beta values
     for apnam, aper in ccdaper.items():
         if aper.ref:
             ref = True
@@ -1579,7 +1580,6 @@ def moveApers(cnam, ccd, read, gain, ccdaper, ccdwin, rfile, store):
 
             try:
                 # get sub-windat around start position
-                shbox = apsec['search_half_width_ref']
                 swdata = wdata.window(
                     aper.x-shbox, aper.x+shbox, aper.y-shbox, aper.y+shbox
                 )
@@ -1616,10 +1616,11 @@ def moveApers(cnam, ccd, read, gain, ccdaper, ccdwin, rfile, store):
                                  apsec['fit_thresh'], apsec['fit_ndiv']
                              )
 
-                # check that x, y are in range
-                if fwdata.distance(x,y) < 0.5:
+                # check that x, y are in range of the original search box.
+                if swdata.distance(x,y) < 0.5:
                     raise hcam.HipercamError(
-                        'Fitted position ({:.1f},{:.1f}) too close or outside window = {!s}'.format(x,y,fwdata.winhead.format())
+                        'Fitted position ({:.1f},{:.1f}) too close to or beyond edge of search window = {!s}'.format(
+                            x,y,fwdata.winhead.format())
                     )
 
                 if height > apsec['fit_height_min']:
@@ -1722,7 +1723,7 @@ def moveApers(cnam, ccd, read, gain, ccdaper, ccdwin, rfile, store):
 
     # now go over all apertures except linked ones. reference
     # apertures are skipped except any that failed are shifted
-    # by the mean shift.
+    # by the mean shift just determined
     for apnam, aper in ccdaper.items():
 
         if aper.ref:
@@ -1743,16 +1744,22 @@ def moveApers(cnam, ccd, read, gain, ccdaper, ccdwin, rfile, store):
 
             try:
 
-                # get sub-window around start position
-                shbox = apsec['search_half_width_non']
-
+                # extract search sub-window around start position. If there were reference
+                # apertures this is only used to check that the position remains OK, but it
+                # should not be an expensive step
                 swdata = wdata.window(
                     aper.x+xshift-shbox, aper.x+xshift+shbox,
                     aper.y+yshift-shbox, aper.y+yshift+shbox
-                )
+                    )
 
-                # carry out initial search
-                x,y,peak = swdata.find(apsec['search_smooth_fwhm'], False)
+                if not ref:
+                    # if there were no reference apertures, we need to carry out a search
+                    x,y,peak = swdata.find(apsec['search_smooth_fwhm'], False)
+
+                else:
+                    # simply apply the reference aperture mean shift
+                    x = aper.x+xshift
+                    y = aper.y+yshift
 
                 # now for a more refined fit. First extract fit Window
                 fhbox = apsec['fit_half_width']
@@ -1788,10 +1795,11 @@ def moveApers(cnam, ccd, read, gain, ccdaper, ccdwin, rfile, store):
                                  apsec['fit_thresh'], apsec['fit_ndiv']
                              )
 
-                # check that x, y are in range
-                if fwdata.distance(x,y) < 0.5:
+                # this is where the search window gets used.
+                if swdata.distance(x,y) < 0.5:
                     raise hcam.HipercamError(
-                        'Fitted position ({:.1f},{:.1f}) too close or outside window = {!s}'.format(x,y,fwdata.winhead.format())
+                        'Fitted position ({:.1f},{:.1f}) too close to or beyond edge of search window = {!s}'.format(
+                            x,y,fwdata.winhead.format())
                     )
 
                 if height > apsec['fit_height_min']:
@@ -1837,8 +1845,8 @@ def moveApers(cnam, ccd, read, gain, ccdaper, ccdwin, rfile, store):
 
             except hcam.HipercamError as err:
                 print(
-                    'CCD {:s}, aperture {:s}, fit failed'.format(
-                        cnam, apnam), file=sys.stderr
+                    'CCD {:s}, aperture {:s}, fit failed, error = {!s}'.format(
+                        cnam, apnam, err), file=sys.stderr
                 )
                 aper.x += xshift
                 aper.y += yshift


### PR DESCRIPTION
From @trmrsh,

> 1) I now flag an error if an aperture moves beyond the search box (with the change I made yesterday, I was not not quite doing this)

> 2) If there are reference apertures in play, I now **skip the search step on any non-reference apertures**, and instead go straight to fitting based on the offset determined from the reference apertures. I think this is a much more robust approach (might be what I do in the ULTRACAM pipeline indeed). It obviates the need for separate half widths for reference and non-reference searches, so I have changed genred and reduce to have just a single value now for the search width (new version number! old reduce files will not work with new version). I have also improved things now so that genred allows you to set the search half and the profile fit half widths separately. There is in fact nothing wrong with using a search half width smaller than the profile fit half width if guiding is good, or vice versa, so these should not have been set to be the same anyway. Even though the non-reference targets are not specifically searched, just fitted, I will still abort the extraction for them if their position moves outside the search box.