### PR TITLE
Added "cmax" to psf_reduce.py

### DIFF
--- a/hipercam/scripts/psf_reduce.py
+++ b/hipercam/scripts/psf_reduce.py
@@ -765,6 +765,7 @@ def extractFlux(cnam, ccd, rccd, read, gain, ccdwin, rfile, store):
                 "nsky": 0,
                 "nrej": 0,
                 "flag": flag,
+                "cmax": 0,
             }
         return results
 
@@ -801,6 +802,7 @@ def extractFlux(cnam, ccd, rccd, read, gain, ccdwin, rfile, store):
                 "nsky": 0,
                 "nrej": 0,
                 "flag": flag,
+                "cmax": 0,
             }
             return results
     wnam = wnames.pop()
@@ -909,14 +911,18 @@ def extractFlux(cnam, ccd, rccd, read, gain, ccdwin, rfile, store):
                 raise hcam.HipercamError("no valid pixels in aperture")
 
             # check for saturation and nonlinearity
+            cmax = int(swraw.data[dok].max())
             if cnam in rfile.warn:
-                if swraw.data[dok].max() >= rfile.warn[cnam]["saturation"]:
+                if cmax >= rfile.warn[cnam]["saturation"]:
                     flag |= hcam.TARGET_SATURATED
 
-                if swraw.data[dok].max() >= rfile.warn[cnam]["nonlinear"]:
+                if cmax >= rfile.warn[cnam]["nonlinear"]:
                     flag |= hcam.TARGET_NONLINEAR
+
             else:
-                warnings.warn("CCD {:s} has no nonlinearity or saturation levels set")
+                warnings.warn(
+                    "CCD {:s} has no nonlinearity or saturation levels set".format(cnam)
+                )
 
             counts = result_row["flux_fit"]
             countse = result_row["flux_unc"]
@@ -938,6 +944,7 @@ def extractFlux(cnam, ccd, rccd, read, gain, ccdwin, rfile, store):
                 "nsky": 0,
                 "nrej": 0,
                 "flag": flag,
+                "cmax": cmax
             }
 
         except hcam.HipercamError as err:
@@ -961,6 +968,7 @@ def extractFlux(cnam, ccd, rccd, read, gain, ccdwin, rfile, store):
                 "nsky": 0,
                 "nrej": 0,
                 "flag": flag,
+                "cmax": 0,
             }
 
     # finally, we are done


### PR DESCRIPTION
psf_reduce.py no longer worked due to the `cmax` key not being included in the results dictionary returned by `extractFlux()`. This fixes the issue by copying the relevant parts from reduce.py. 