### PR TITLE
Fixed float32/64 dtype for >65535

### DIFF
--- a/hipercam/scripts/joinup.py
+++ b/hipercam/scripts/joinup.py
@@ -399,7 +399,7 @@ def joinup(args=None):
                         ystart = (wind.lly - llymin) // ybin
                         data[ystart:ystart+wind.ny,xstart:xstart+wind.nx] = wind.data
 
-                    if dtype == 'uint16' and data.min() < 0 or data.max() > 65535:
+                    if dtype == 'uint16' and (data.min() < 0 or data.max() > 65535):
                         raise hcam.HipercamError(
                             f'CCD {cnam}, frame {nf}, data range {data.min()} to {data.max()}, is incompatible with uint16'
                         )


### PR DESCRIPTION
Hi Tom,
A quick fix to some missing brackets I found.
It wasn't happy debiasing and flatfielding an image even when float32 or float64 were selected. just a small logic typo.
Alex