### PR TITLE
Acquisition runs can be called data caution or acquisition

### DIFF
--- a/hipercam/scripts/hlogger.py
+++ b/hipercam/scripts/hlogger.py
@@ -675,7 +675,7 @@ def hlogger(args=None):
                             itype = hd.get("IMAGETYP", '')
                         else:
                             itype = hd.get("DTYPE", '')
-                        if itype == 'data caution':
+                        if itype == 'acquisition' or itype == 'data caution':
                             itype = 'acquire'
                         nhtml.write(f'<td class="left">{itype}</td>')
                         brow.append(itype)


### PR DESCRIPTION
To accommodate a request from the GTC, runs flagged as acquire now have a data type of "acquisition" compared to the old "data caution". 