### PR TITLE
Select flats on median values as well as mean

### DIFF
--- a/hipercam/scripts/makeflat.py
+++ b/hipercam/scripts/makeflat.py
@@ -349,9 +349,6 @@ def makeflat(args=None):
                 os.close(fd)
 
                 # a bit of progress info
-                nframe = mccd.head["NFRAME"]
-                cvalues = [(means[cnam][fname], medians[cnam][fname]) for cnam in ccds]
-                print(f"Frame {nframe}: {cvalues}")
                 print(f"Saved processed flat to {fname}")
 
         # now we go through CCD by CCD, using the first as a template


### PR DESCRIPTION
To fix #113, a simple addition is to only select frames if their mean _and median_ are both within the requested limits. This will reject the initial saturated images from HiPERCAM where half the frame gives 0 counts and remove the structure from the flats.

Before:
![before](https://github.com/HiPERCAM/hipercam/assets/15014527/3f93a0aa-535d-4f7c-bbf4-b4eec9888892)

After:
![after](https://github.com/HiPERCAM/hipercam/assets/15014527/69214b6a-dd89-436a-b748-59f1e8a375a3)
