### PR TITLE
Only try to plot apertures in reduce if they are defined for that CCD

### DIFF
--- a/hipercam/reduction.py
+++ b/hipercam/reduction.py
@@ -988,7 +988,8 @@ def update_plots(
                 else:
                     message += "ccd {:s}: {:.2f} to {:.2f}".format(cnam, vmin, vmax)
 
-                if cnam in rfile.aper:
+                # plot apertures
+                if cnam in rfile.aper and len(rfile.aper[cnam]) > 0:
                     # find the result for this ccd name
                     res = next(res for (this_cnam, res) in results if this_cnam == cnam)
                     # we always use the last result in the parallel group

--- a/hipercam/window.py
+++ b/hipercam/window.py
@@ -19,8 +19,7 @@ from numpy.lib.stride_tricks import as_strided
 
 from astropy.io import fits
 from astropy.convolution import Gaussian2DKernel, convolve, convolve_fft
-from scipy.ndimage.filters import maximum_filter
-from scipy.ndimage import gaussian_filter
+from scipy.ndimage import gaussian_filter, maximum_filter
 
 import matplotlib.pyplot as plt
 from .core import *


### PR DESCRIPTION
Explanation in #123, closes #123 and possibly #115?

I also included the minor change to remove scipy deprecation warnings, to close #120.