### PR TITLE
Better polling of hipercam server

### DIFF
--- a/hipercam/hcam.py
+++ b/hipercam/hcam.py
@@ -874,7 +874,7 @@ class Rdata(Rhead):
                 # just want the last complete frame.
                 # If this is not at least one further on than the latest
                 # frame we have, we return with None to indicate no progress.
-                if self.ntotal() <= self.nframe:
+                if self.ntotal() < self.nframe:
                     return None
                 # Note that further down we check the frame counter against what we were
                 # hoping for (at least 1 further on) to check for issues.

--- a/hipercam/hcam.py
+++ b/hipercam/hcam.py
@@ -889,6 +889,9 @@ class Rdata(Rhead):
 
                 if nget == self.nframe:
                     request = json.dumps(dict(action="get_next"))
+                elif nget < self.nframe:
+                    # we have already read frame nget, so return None for now
+                    return None
                 else:
                     request = json.dumps(dict(action="get_frame", frame_number=nget))
                     self.nframe = nget


### PR DESCRIPTION
There were a few bugs in the `Rdata` class that meant that polling over the network was less efficient than it needed to be. 

If we were trying to get the last frame (`first=0`), then the method used was to grab the last frame available, and check the frame number returned in that data vs the expected frame number.

So if we wanted frame 50, and frame 49 was the latest, Rdata would transfer across frame 49 over and over, checking the frame number and returning `None` when it was not 50.

This PR changes that behaviour, so that we check if the frame is available before transferring any data. 

At the same time, we fix a bug with `first = -X` which would result in the same frame being transferred multiple times if the desired frame was not available yet.