### PR TITLE
Create pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+build-backend = 'setuptools.build_meta'
+requires = [
+    'setuptools >= 40.9.0',
+    'cython',
+    'numpy<2.0',
+    ]


### PR DESCRIPTION
In more recent versions of python (>3.11) the Cython compiling fails as the setuptools have changed and requires numpy to be installable in isolation. The easiest fix is to use pyproject.toml defining the requirements. It's currently requiring numpy<2.0 as everything breaks with numpy 2.0 at the moment. In the future the toml file could be expanded to contain more project info which currently sits in the setup.py.