### PR TITLE
Correctly read pre-2010 ulog files

### DIFF
--- a/hipercam/hlog.py
+++ b/hipercam/hlog.py
@@ -322,11 +322,13 @@ class Hlog(dict):
 
         hlog = cls()
         hlog.apnames = {}
+        hlog.cnames = {}
 
         with fits.open(fname) as hdul:
             for hdu in hdul[1:]:
                 cnam = hdu.header["CCDNAME"]
                 hlog[cnam] = hdu.data
+                hlog.cnames[cnam] = list(hdu.data.names)
                 hlog.apnames[cnam] = list(
                     set(
                         [
@@ -350,9 +352,9 @@ class Hlog(dict):
 
         hlog = cls()
         hlog.apnames = {}
+        hlog.cnames = {}
 
         # CCD labels, number of apertures, numpy dtypes, struct types
-        cnames = {}
         naps = {}
         dtypes = {}
         stypes = {}
@@ -519,6 +521,7 @@ class Hlog(dict):
                                 int(error_flag),
                             ]
 
+                        hlog.cnames[cnam] = names
                         dtypes[cnam] = np.dtype(list(zip(names, dts)))
                         stypes[cnam] = "=" + "".join(
                             [NUMPY_TO_STRUCT[dt] for dt in dts]

--- a/hipercam/scripts/hlog2col.py
+++ b/hipercam/scripts/hlog2col.py
@@ -103,7 +103,7 @@ def hlog2col(args=None):
     if origin == "h":
         hlg = hcam.hlog.Hlog.rascii(log)
     elif origin == "u":
-        hlg = hcam.hlog.Hlog.fulog(log)
+        hlg = hcam.hlog.Hlog.rulog(log)
 
     print(f"Loaded ASCII log = {log}")
 

--- a/hipercam/scripts/hlog2fits.py
+++ b/hipercam/scripts/hlog2fits.py
@@ -95,7 +95,7 @@ def hlog2fits(args=None):
     if origin == "h":
         hlg = hcam.hlog.Hlog.rascii(log)
     elif origin == "u":
-        hlg = hcam.hlog.Hlog.fulog(log)
+        hlg = hcam.hlog.Hlog.rulog(log)
 
     print(f"Loaded ASCII log = {log}")
 


### PR DESCRIPTION
This comes from @SGParsons finding an error when trying to read a log file from 2005 (!).

It turns out in March 2010 the ULTRACAM GPS system changed and the number of satellites was removed from the reduce output log. See https://github.com/trmrsh/cpp-ultracam/commit/b71b367a0fd4ff88de0d70ce901279c2d1be55fa and https://github.com/trmrsh/cpp-ultracam/commit/24d5b4ca8e8238c1971acdb6716a62653bd5db8e.

This PR adds code into the `hlog.Hlog.rulog()` method to allow pre-2010 log files to be read in, based on Tom's additions to `ulog2fits` in the latter commit. It basically just checks the column names if `nsat` is included, and adjusts reading in accordingly.

I've tested this with pre and post 2010 logs Steven provided, and they both seem to work now. 

I also tried `hlog2fits` and `hlog2col`, which lead to me finding a few more bugs: both called `fulog` instead of `rulog`, and neither `rulog` or `rfits` properly stored the column names when reading in (as `hlog.cnames`, not to be confused with `cnam` when used for the ccd name!!). Anyway I've fixed those too, so now `hlog2col` should work correctly with `origin=u`.
