### PR TITLE
Fix minor bug in shiftadd

### DIFF
--- a/hipercam/scripts/shiftadd.py
+++ b/hipercam/scripts/shiftadd.py
@@ -417,13 +417,12 @@ def shiftadd(args=None):
             args += [
                 calsec["fmap"],
                 calsec["fpair"],
-                calsec["nhalf"],
-                calsec["rmin"],
-                calsec["rmax"],
+                str(calsec["nhalf"]),
+                str(calsec["rmin"]),
+                str(calsec["rmax"]),
                 "false",
                 "f32",
             ]
-
         resource = hcam.scripts.grab(args)
 
     # at this point 'resource' is a list of files, no matter the input


### PR DESCRIPTION
We had a minor bug in the arguments to `grab` within shiftadd - the arguments need to be of type string