### PR TITLE
Move towards pyproject.toml

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ Docker Installation
 ===================
 
 The easiest way to install hipercam is to create a Docker image. This
-is simple and cross-platform, but the image is large (around 2.8GB). To 
+is simple and cross-platform, but the image is large (around 2.8GB). To
 install via this route, please download the
 `dockerfile <https://raw.githubusercontent.com/HiPERCAM/hipercam/refs/heads/master/data/hipercam.dockerfile>`_
 
@@ -38,14 +38,14 @@ MacOS
 +++++
 
 Installation on Apple Silicon Macs is a little more complicated. The instructions below assume you have a modern
-MacOS/Apple Silicon system with Docker Desktop installed. 
+MacOS/Apple Silicon system with Docker Desktop installed.
 
 To build the docker image from the docker file, run::
 
   docker build -t hipercam:latest --platform linux/amd64 -f hipercam.dockerfile .
 
 And, to run the image, use::
-       
+
   xhost +
   docker run -it -e DISPLAY=host.docker.internal:0 --platform linux/amd64 --rm -v <local-path-to-some-data>:/home/hiperuser/data hipercam:latest
 
@@ -77,6 +77,44 @@ I use the Qt5Agg backend to ensure that the important command
 |setaper| works. Others may work too of course. I have this set as the
 default in my .config/matplotlib/matplotlibrc configuartion file with
 the line `backend: Qt5Agg`
+
+Building from Source
+====================
+
+You can build the package from source using the standard Python build tools.
+
+Prerequisites
++++++++++++++
+
+Make sure you have the required build tools installed::
+
+  pip install build
+
+Basic Build Commands
+++++++++++++++++++++
+
+To build a source distribution (tarball)::
+
+  python -m build --sdist
+
+To build a wheel (binary distribution)::
+
+  python -m build --wheel
+
+To build both source and wheel distributions::
+
+  python -m build
+
+For development, you can install the package in editable mode::
+
+  pip install -e .
+
+This will install the package in development mode, so changes to the
+source code are immediately reflected without needing to reinstall.
+
+Note: The package includes Cython extensions that need to be compiled,
+so you'll need a C compiler and the build dependencies (Cython, numpy)
+available during the build process.
 
 Third-Party Modules
 ===================
@@ -137,7 +175,7 @@ your O/S package manager. e.g. under fedora, Cython appears as
          astronomical source extractor based on Bertin's source extractor.
 
   reproject:
-         The reproject package implements image reprojection methods 
+         The reproject package implements image reprojection methods
          for astronomical images. This is an optional dependency,
          but you will need it for `shiftadd` to work.
 
@@ -169,7 +207,7 @@ your O/S package manager. e.g. under fedora, Cython appears as
   trm.utils :
          generally useful routines used at a few places. Available
 	 from PyPi.
-	 
+
   websocket-client :
          for talking to the hipercam server.
 
@@ -182,7 +220,7 @@ your O/S package manager. e.g. under fedora, Cython appears as
 Contributing
 ===================
 The hipercam pipeline is made for its users, and we welcome contributions of many kinds.
-If you notice a bug, or want to request new functionality, please 
+If you notice a bug, or want to request new functionality, please
 `raise an issue <https://github.com/HiPERCAM/hipercam/issues>`_ or consider submitting
 a `pull request <https://github.com/HiPERCAM/hipercam/pulls>`_.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,118 @@
+[build-system]
+requires = ["setuptools>=61.0", "setuptools-scm", "wheel", "Cython", "numpy"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "hipercam"
+dynamic = ["version"]
+description = "multi-CCD astronomical reduction suite"
+readme = "README.rst"
+license = "BSD-3-Clause"
+authors = [
+    {name = "Tom Marsh", email = "t.r.marsh@warwick.ac.uk"}
+]
+keywords = ["astronomy", "photometry", "reduction"]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Science/Research",
+    "Topic :: Scientific/Engineering :: Astronomy",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.6",
+]
+requires-python = ">=3.6"
+dependencies = [
+    "astropy",
+    "Cython",
+    "fitsio",
+    "keyring",
+    "matplotlib",
+    "numba",
+    "numpy",
+    "pandas",
+    "requests",
+    "sep>=1.4",
+    "trm.cline",
+    "trm.utils",
+    "urllib3>=1.26.5",
+    "websocket-client",
+]
+
+[project.optional-dependencies]
+dev = ["check-manifest"]
+test = ["coverage", "nose"]
+
+[project.urls]
+Homepage = "https://github.com/HiPERCAM/hipercam"
+Repository = "https://github.com/HiPERCAM/hipercam"
+
+[project.scripts]
+add = "hipercam.scripts.arith:add"
+aligntool = "hipercam.scripts.aligntool:aligntool"
+atanalysis = "hipercam.scripts.atanalysis:atanalysis"
+atbytes = "hipercam.scripts.atbytes:atbytes"
+averun = "hipercam.scripts.averun:averun"
+cadd = "hipercam.scripts.carith:cadd"
+calsearch = "hipercam.scripts.calsearch:calsearch"
+cdiv = "hipercam.scripts.carith:cdiv"
+cmul = "hipercam.scripts.carith:cmul"
+combine = "hipercam.scripts.combine:combine"
+csub = "hipercam.scripts.carith:csub"
+div = "hipercam.scripts.arith:div"
+exploss = "hipercam.scripts.exploss:exploss"
+filtid = "hipercam.scripts.filtid:filtid"
+fits2hcm = "hipercam.scripts.fits2hcm:fits2hcm"
+flagcloud = "hipercam.scripts.flagcloud:flagcloud"
+ftargets = "hipercam.scripts.ftargets:ftargets"
+genred = "hipercam.scripts.genred:genred"
+grab = "hipercam.scripts.grab:grab"
+harchive = "hipercam.scripts.harchive:harchive"
+hfilter = "hipercam.scripts.hfilter:hfilter"
+hinfo = "hipercam.scripts.hinfo:hinfo"
+hist = "hipercam.scripts.hist:hist"
+hlogger = "hipercam.scripts.hlogger:hlogger"
+hlog2col = "hipercam.scripts.hlog2col:hlog2col"
+hlog2fits = "hipercam.scripts.hlog2fits:hlog2fits"
+hls = "hipercam.scripts.hls:hls"
+hmeta = "hipercam.scripts.hmeta:hmeta"
+hpackage = "hipercam.scripts.hpackage:hpackage"
+hplot = "hipercam.scripts.hplot:hplot"
+joinup = "hipercam.scripts.joinup:joinup"
+jtrawl = "hipercam.scripts.jtrawl:jtrawl"
+logsearch = "hipercam.scripts.logsearch:logsearch"
+ltimes = "hipercam.scripts.ltimes:ltimes"
+ltrans = "hipercam.scripts.ltrans:ltrans"
+makebias = "hipercam.scripts.makebias:makebias"
+makedark = "hipercam.scripts.makedark:makedark"
+makefield = "hipercam.scripts.makestuff:makefield"
+makeflat = "hipercam.scripts.makeflat:makeflat"
+makefringe = "hipercam.scripts.makefringe:makefringe"
+makemccd = "hipercam.scripts.makestuff:makemccd"
+makemovie = "hipercam.scripts.makemovie:makemovie"
+mstats = "hipercam.scripts.mstats:mstats"
+mul = "hipercam.scripts.arith:mul"
+ncal = "hipercam.scripts.ncal:ncal"
+pbands = "hipercam.scripts.pbands:pbands"
+pfolder = "hipercam.scripts.pfolder:pfolder"
+plog = "hipercam.scripts.plog:plog"
+redanal = "hipercam.scripts.redanal:redanal"
+redplt = "hipercam.scripts.redplt:redplt"
+reduce = "hipercam.scripts.reduce:reduce"
+rtplot = "hipercam.scripts.rtplot:rtplot"
+nrtplot = "hipercam.scripts.nrtplot:nrtplot"
+rupdate = "hipercam.scripts.rupdate:rupdate"
+setaper = "hipercam.scripts.setaper:setaper"
+setdefect = "hipercam.scripts.setdefect:setdefect"
+setfringe = "hipercam.scripts.setfringe:setfringe"
+shiftadd = "hipercam.scripts.shiftadd:shiftadd"
+splice = "hipercam.scripts.splice:splice"
+stats = "hipercam.scripts.stats:stats"
+sub = "hipercam.scripts.arith:sub"
+tanalysis = "hipercam.scripts.tanalysis:tanalysis"
+tbytes = "hipercam.scripts.tbytes:tbytes"
+uls = "hipercam.scripts.uls:uls"
+
+[tool.setuptools]
+packages = {find = {exclude = ["contrib", "docs", "tests"]}}
+
+[tool.setuptools_scm]
+# This enables setuptools to automatically set the full version based on the git history

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,13 +20,3 @@ doctest_plus = enabled
 
 [ah_bootstrap]
 auto_use = True
-
-[metadata]
-package_name = hipercam
-description = Multi-CCD reduction package
-long_description = This is a package for reducing data from the high-speed camera HiPERCAM
-author = Tom Marsh
-author_email = t.r.marsh@warwick.ac.uk
-license = BSD
-url = http://www.astro.warwick.ac.uk/
-

--- a/setup.py
+++ b/setup.py
@@ -1,21 +1,13 @@
 """
-hipercam setup file
+Minimal setup.py for Cython extension support.
+All other metadata is in pyproject.toml.
 """
 
 import os
-
-# To use a consistent encoding
-from codecs import open
-
-# need for Cython
 import numpy as np
 from Cython.Build import cythonize
-from setuptools import find_packages, setup
+from setuptools import setup
 from setuptools.extension import Extension
-
-# read the README file for the long description
-with open("README.rst") as f:
-    readme = f.read()
 
 # cython support routine
 extension = [
@@ -29,172 +21,5 @@ extension = [
 ]
 
 setup(
-    name="hipercam",
-    # Versions should comply with PEP440. Here we use a version
-    # generated automatically from git.
-    use_scm_version=True,
-    setup_requires=["setuptools_scm"],
-    description="multi-CCD astronomical reduction suite",
-    long_description=readme,
-    # The project's main homepage.
-    url="https://github.com/HiPERCAM/hipercam",
-    # Author details
-    author="Tom Marsh",
-    author_email="t.r.marsh@warwick.ac.uk",
-    # Choose your license
-    license="BSD",
-    # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
-    classifiers=[
-        # How mature is this project? Common values are
-        #   3 - Alpha
-        #   4 - Beta
-        #   5 - Production/Stable
-        "Development Status :: 5 - Production/Stable",
-        "Development Status :: 5 - Production/Stable",
-        # Indicate who your project is intended for
-        "Intended Audience :: Astronomers",
-        "Topic :: Astronomy :: Photometric reduction",
-        "Intended Audience :: Astronomers",
-        "Topic :: Astronomy :: Photometric reduction",
-        # Pick your license as you wish (should match "license" above)
-        "License :: OSI Approved :: BSD License",
-        "License :: OSI Approved :: BSD License",
-        # Specify the Python versions you support here. In particular, ensure
-        # that you indicate whether you support Python 2, Python 3 or both.
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-    ],
-    # What does your project relate to?
-    keywords="astronomy photometry reduction",
-    # You can just specify the packages manually here if your project is
-    # simple. Or you can use find_packages().
-    packages=find_packages(exclude=["contrib", "docs", "tests"]),
-    # extension modules
     ext_modules=cythonize(extension),
-    # Alternatively, if you want to distribute just a my_module.py, uncomment
-    # this:
-    #   py_modules=["my_module"],
-    # List run-time dependencies here.  These will be installed by pip
-    # when your project is installed. For an analysis of
-    # "install_requires" vs pip's requirements files see:
-    # https://packaging.python.org/en/latest/requirements.html
-    # urllib3 requirement to get over a security warning
-    install_requires=[
-        "astropy",
-        "Cython",
-        "fitsio",
-        "keyring",
-        "matplotlib",
-        "numba",
-        "numpy",
-        "pandas",
-        "requests",
-        "sep>=1.4",
-        "trm.cline",
-        "trm.utils",
-        "urllib3>=1.26.5",
-        "websocket-client",
-    ],
-    # Makes significant use of f-strings which came in python v3.6
-    python_requires=">=3.6",
-    # List additional groups of dependencies here (e.g. development
-    # dependencies). You can install these using the following syntax,
-    # for example:
-    # $ pip install -e .[dev,test]
-    extras_require={
-        "dev": ["check-manifest"],
-        "test": ["coverage"],
-        "dev": ["check-manifest"],
-        "test": ["coverage"],
-    },
-    # If there are data files included in your packages that need to be
-    # installed, specify them here.  If using Python 2.6 or less, then these
-    # have to be included in MANIFEST.in as well.
-    # package_data={
-    # package_data={
-    #    'sample': ['package_data.dat'],
-    # },
-    # },
-    # Although 'package_data' is the preferred approach, in some case you may
-    # need to place data files outside of your packages. See:
-    # http://docs.python.org/3.4/distutils/setupscript.html#installing-additional-files # noqa
-    # In this case, 'data_file' will be installed into '<sys.prefix>/my_data'
-    # data_files=[('my_data', ['data/data_file'])],
-    # data_files=[('my_data', ['data/data_file'])],
-    # To provide executable scripts, use entry points in preference to the
-    # "scripts" keyword. Entry points provide cross-platform support and allow
-    # pip to create the appropriate form of executable for the target platform.
-    entry_points={
-        "console_scripts": [
-            "add=hipercam.scripts.arith:add",
-            "aligntool=hipercam.scripts.aligntool:aligntool",
-            "atanalysis=hipercam.scripts.atanalysis:atanalysis",
-            "atbytes=hipercam.scripts.atbytes:atbytes",
-            "averun=hipercam.scripts.averun:averun",
-            "cadd=hipercam.scripts.carith:cadd",
-            "calsearch=hipercam.scripts.calsearch:calsearch",
-            "cdiv=hipercam.scripts.carith:cdiv",
-            "cmul=hipercam.scripts.carith:cmul",
-            "combine=hipercam.scripts.combine:combine",
-            "csub=hipercam.scripts.carith:csub",
-            "div=hipercam.scripts.arith:div",
-            "exploss=hipercam.scripts.exploss:exploss",
-            "filtid=hipercam.scripts.filtid:filtid",
-            "fits2hcm=hipercam.scripts.fits2hcm:fits2hcm",
-            "flagcloud=hipercam.scripts.flagcloud:flagcloud",
-            "ftargets=hipercam.scripts.ftargets:ftargets",
-            "genred=hipercam.scripts.genred:genred",
-            "grab=hipercam.scripts.grab:grab",
-            "harchive=hipercam.scripts.harchive:harchive",
-            "hfilter=hipercam.scripts.hfilter:hfilter",
-            "hinfo=hipercam.scripts.hinfo:hinfo",
-            "hist=hipercam.scripts.hist:hist",
-            "hlogger=hipercam.scripts.hlogger:hlogger",
-            "hlog2col=hipercam.scripts.hlog2col:hlog2col",
-            "hlog2fits=hipercam.scripts.hlog2fits:hlog2fits",
-            "hls=hipercam.scripts.hls:hls",
-            "hmeta=hipercam.scripts.hmeta:hmeta",
-            "hpackage=hipercam.scripts.hpackage:hpackage",
-            "hplot=hipercam.scripts.hplot:hplot",
-            "joinup=hipercam.scripts.joinup:joinup",
-            "jtrawl=hipercam.scripts.jtrawl:jtrawl",
-            "logsearch=hipercam.scripts.logsearch:logsearch",
-            "ltimes=hipercam.scripts.ltimes:ltimes",
-            "ltrans=hipercam.scripts.ltrans:ltrans",
-            "makebias=hipercam.scripts.makebias:makebias",
-            "makedark=hipercam.scripts.makedark:makedark",
-            "makefield=hipercam.scripts.makestuff:makefield",
-            "makeflat=hipercam.scripts.makeflat:makeflat",
-            "makefringe=hipercam.scripts.makefringe:makefringe",
-            "makemccd=hipercam.scripts.makestuff:makemccd",
-            "makemovie=hipercam.scripts.makemovie:makemovie",
-            "mstats=hipercam.scripts.mstats:mstats",
-            "mul=hipercam.scripts.arith:mul",
-            "ncal=hipercam.scripts.ncal:ncal",
-            "pbands=hipercam.scripts.pbands:pbands",
-            "pfolder=hipercam.scripts.pfolder:pfolder",
-            "plog=hipercam.scripts.plog:plog",
-            "redanal=hipercam.scripts.redanal:redanal",
-            "redplt=hipercam.scripts.redplt:redplt",
-            "reduce=hipercam.scripts.reduce:reduce",
-            "rtplot=hipercam.scripts.rtplot:rtplot",
-            "nrtplot=hipercam.scripts.nrtplot:nrtplot",
-            "rupdate=hipercam.scripts.rupdate:rupdate",
-            "setaper=hipercam.scripts.setaper:setaper",
-            "setdefect=hipercam.scripts.setdefect:setdefect",
-            "setfringe=hipercam.scripts.setfringe:setfringe",
-            "shiftadd=hipercam.scripts.shiftadd:shiftadd",
-            "splice=hipercam.scripts.splice:splice",
-            "stats=hipercam.scripts.stats:stats",
-            "sub=hipercam.scripts.arith:sub",
-            "tanalysis=hipercam.scripts.tanalysis:tanalysis",
-            "tbytes=hipercam.scripts.tbytes:tbytes",
-            "uls=hipercam.scripts.uls:uls",
-        ],
-    },
-    # tests
-    test_suite="nose.collector",
-    tests_require=["nose", "numpy", "astropy"],
 )


### PR DESCRIPTION
Here's a start at moving towards modern Python package standards by adding a `pyproject.toml` file. 

I've simply moved all the metadata out of `setup.py` (and removed the duplicates in `setup.cfg`) to fit the new standard, but I haven't changed or reviewed any of it since this is just meant to be a basic initial implementation. We'd definitely want to update a lot of it before publishing to PyPI for instance. 

`setup.py` still exists to handle the cythonizing just as before, with a change of backend we could move that into `pyproject.toml` but it's not uncommon for projects to keep a residual setup.py file for cases like this (e.g. https://github.com/astropy/astropy/blob/main/setup.py). Or more likely we'd just want to replace Cython entirely, but again that's better left for a bigger full refresh.

I also added some basic build commands to the README for good measure.

This is a slightly more advanced version of @bretonr's PR #133. @StuartLittlefair and @paulkerry1 would probably also want to have a look to check it still builds/installs correctly, it seems on my laptop but I wouldn't want to break installing on any of the Sheffield/ULTRACAM/etc systems (and I'm also only on Python 3.11, so I don't see the wheel error from https://github.com/HiPERCAM/hipercam/pull/133#issuecomment-3236476529). I did get an error trying to install `trm-pgplot` with a newer numpy, but that's a separate issue.