### PR TITLE
add option to plot bad times in plog

### DIFF
--- a/hipercam/scripts/pbands.py
+++ b/hipercam/scripts/pbands.py
@@ -97,7 +97,7 @@ def pbands(args=None):
          colours for each CCD, space or comma-separated.
          e.g. "r,g,b" or "r g b" (without quotes).
 
-      badtimes: bool [hidden]
+      badtime: bool [hidden]
          plot points marked as bad time in the log file. Default False.
 
     """
@@ -130,7 +130,7 @@ def pbands(args=None):
         cl.register("over", Cline.LOCAL, Cline.PROMPT)
         cl.register("title", Cline.LOCAL, Cline.PROMPT)
         cl.register("colours", Cline.LOCAL, Cline.PROMPT)
-        cl.register("badtimes", Cline.LOCAL, Cline.HIDE)
+        cl.register("", Cline.LOCAL, Cline.HIDE)
 
         # get inputs
         log = cl.get_value(
@@ -197,7 +197,7 @@ def pbands(args=None):
         colours = cl.get_value("colours", "colours [strings, one per CCD]", colours)
 
         # plot points marked as bad time in the log file. Default False.
-        badtimes = cl.get_value("badtimes", "plot points marked as bad time in the log file?", False)
+        badtime = cl.get_value("badtime", "plot points marked as bad time in the log file?", False)
 
     if width > 0 and height > 0:
         fig, axs = plt.subplots(
@@ -214,7 +214,7 @@ def pbands(args=None):
 
     # light curves
     bitmask = hcam.JUNK
-    if not badtimes:
+    if not badtime:
         bitmask |= hcam.BAD_TIME
 
     for ccd, ax, col in zip(ccds, axs[:, 0], colours):

--- a/hipercam/scripts/pbands.py
+++ b/hipercam/scripts/pbands.py
@@ -97,6 +97,9 @@ def pbands(args=None):
          colours for each CCD, space or comma-separated.
          e.g. "r,g,b" or "r g b" (without quotes).
 
+      badtimes: bool [hidden]
+         plot points marked as bad time in the log file. Default False.
+
     """
 
     command, args = cline.script_args(args)
@@ -127,6 +130,7 @@ def pbands(args=None):
         cl.register("over", Cline.LOCAL, Cline.PROMPT)
         cl.register("title", Cline.LOCAL, Cline.PROMPT)
         cl.register("colours", Cline.LOCAL, Cline.PROMPT)
+        cl.register("badtimes", Cline.LOCAL, Cline.HIDE)
 
         # get inputs
         log = cl.get_value(
@@ -192,6 +196,9 @@ def pbands(args=None):
             cl.set_default("colours", colours)
         colours = cl.get_value("colours", "colours [strings, one per CCD]", colours)
 
+        # plot points marked as bad time in the log file. Default False.
+        badtimes = cl.get_value("badtimes", "plot points marked as bad time in the log file?", False)
+
     if width > 0 and height > 0:
         fig, axs = plt.subplots(
             len(ccds),
@@ -206,6 +213,10 @@ def pbands(args=None):
         )
 
     # light curves
+    bitmask = hcam.JUNK
+    if not badtimes:
+        bitmask |= hcam.BAD_TIME
+
     for ccd, ax, col in zip(ccds, axs[:, 0], colours):
         utils.style_mpl_axes(ax)
         targ = hlog.tseries(ccd, aper1, "counts")
@@ -215,12 +226,12 @@ def pbands(args=None):
         if norm:
             targ.normalise()
         if line:
-            targ.mplot(ax, col, "-", bitmask=hcam.BAD_TIME | hcam.JUNK, erry=error)
-        targ.mplot(ax, col, bitmask=hcam.BAD_TIME | hcam.JUNK, ms=ms, erry=error)
+            targ.mplot(ax, col, "-", bitmask=bitmask, erry=error)
+        targ.mplot(ax, col, bitmask=bitmask, ms=ms, erry=error)
 
         # plot limits
-        _d, y1, _d = targ.percentile(plo, hcam.BAD_TIME | hcam.JUNK)
-        _d, _d, y2 = targ.percentile(phi, hcam.BAD_TIME | hcam.JUNK)
+        _d, y1, _d = targ.percentile(plo, bitmask)
+        _d, _d, y2 = targ.percentile(phi, bitmask)
         if zero:
             y1 = 0.0
             y2 *= 1 + increment
@@ -246,7 +257,7 @@ def pbands(args=None):
                 targ /= comp
 
             # extract data
-            ts, _d, ys, yes = targ.get_data(hcam.BAD_TIME | hcam.JUNK)
+            ts, _d, ys, yes = targ.get_data(bitmask)
             ls = LombScargle(ts, ys, yes)
             f, p = ls.autopower(
                 minimum_frequency=flo, maximum_frequency=fhi, samples_per_peak=over

--- a/hipercam/scripts/plog.py
+++ b/hipercam/scripts/plog.py
@@ -1,10 +1,9 @@
-import sys
 import os
+import sys
 
-import numpy as np
 import matplotlib as mpl
 import matplotlib.pyplot as plt
-
+import numpy as np
 from trm import cline
 from trm.cline import Cline
 
@@ -71,6 +70,9 @@ def plog(args=None):
       title : str [hidden]
          plot title. Defaults to the run number if not specified
 
+      badtime : bool [hidden]
+         plot points marked as bad time in the log file. Default False.
+
     .. Note::
 
        Points marked bad, or flagged as having bad times or junk are
@@ -100,6 +102,7 @@ def plog(args=None):
         cl.register("param2", Cline.LOCAL, Cline.PROMPT)
         cl.register("scheme", Cline.LOCAL, Cline.PROMPT)
         cl.register("title", Cline.LOCAL, Cline.HIDE)
+        cl.register("badtime", Cline.LOCAL, Cline.HIDE)
 
         # get inputs
         log = cl.get_value(
@@ -148,6 +151,7 @@ def plog(args=None):
 
         cl.set_default("title", log)
         title = cl.get_value("title", "plot title", "Plot Title")
+        badtime = cl.get_value("badtime", "plot points marked as bad time?", False)
 
     # load the reduce log
     hlog = hcam.hlog.Hlog.rascii(log)
@@ -159,32 +163,37 @@ def plog(args=None):
 
     dat1 = hlog.tseries(ccd1, aper1, pname1)
 
+    # bitmask for points to ignore
+    bitmask = hcam.JUNK
+    if not badtime:
+        bitmask |= hcam.BAD_TIME
+
     if ccd2 != "!":
         dat2 = hlog.tseries(ccd2, aper2, pname2)
         if scheme == "b":
             # plots both together
-            dat1.mplot(plt, "b", bitmask=hcam.BAD_TIME|hcam.JUNK)
-            dat2.mplot(plt, "r", bitmask=hcam.BAD_TIME|hcam.JUNK)
+            dat1.mplot(plt, "b", bitmask=bitmask)
+            dat2.mplot(plt, "r", bitmask=bitmask)
             xlabel = "Time [MJD]"
             ylabel = "{:s} & {:s}".format(lab1, lab2)
 
         elif scheme == "r":
             # ratio
             ratio = dat1 / dat2
-            ratio.mplot(plt, "b", bitmask=hcam.BAD_TIME|hcam.JUNK)
+            ratio.mplot(plt, "b", bitmask=bitmask)
             xlabel = "Time [MJD]"
             ylabel = "{:s} / {:s}".format(lab1, lab2)
 
         elif scheme == "d":
             # difference
             diff = dat1 - dat2
-            diff.mplot(plt, "b", bitmask=hcam.BAD_TIME|hcam.JUNK)
+            diff.mplot(plt, "b", bitmask=bitmask)
             xlabel = "Time [MJD]"
             ylabel = "{:s} - {:s}".format(lab1, lab2)
 
         elif scheme == "s":
-            mask1 = dat1.get_mask(bitmask=hcam.BAD_TIME|hcam.JUNK, invert=True)
-            mask2 = dat1.get_mask(bitmask=hcam.BAD_TIME|hcam.JUNK, invert=True)
+            mask1 = dat1.get_mask(bitmask=bitmask, invert=True)
+            mask2 = dat1.get_mask(bitmask=bitmask, invert=True)
             ok = ~mask1 & ~mask2
             plt.errorbar(
                 dat1.y[ok], dat2.y[ok], dat2.ye[ok], dat1.ye[ok], ".", capsize=0
@@ -194,7 +203,7 @@ def plog(args=None):
 
     else:
         # just one
-        dat1.mplot(plt, bitmask=hcam.BAD_TIME|hcam.JUNK)
+        dat1.mplot(plt, bitmask=bitmask)
         xlabel = "Time [MJD]"
         ylabel = lab1
 


### PR DESCRIPTION
As noted in #170 `plog` and `pbands` won't plot drift-mode data as all times are marked as bad.

Here we add a hidden argument `badtime` that will allow plotting of these points anyway